### PR TITLE
fix debug call logging to .info()

### DIFF
--- a/cogs/database.py
+++ b/cogs/database.py
@@ -56,7 +56,7 @@ class Database(commands.Cog):
         role_list = list()
         role_str = str()
         if member.guild.id != 460948857304383488:
-            self.bot.logger.info(f"Ignoring leaver not in our guild of interest {member.id} left guild {member.guild.id}.")
+            self.bot.logger.debug(f"Ignoring leaver not in our guild of interest {member.id} left guild {member.guild.id}.")
             return
         if hasattr(member, 'roles'):
             for role in member.roles:


### PR DESCRIPTION
Move un-needed debug statement from .info() to .debug()